### PR TITLE
fixed a bug in building the dihedral list

### DIFF
--- a/berny/coords.py
+++ b/berny/coords.py
@@ -379,14 +379,14 @@ class InternalCoords(object):
 
 
 def get_dihedrals(center, coords, bondmatrix, C, superweak=False):
-    neigh_l = [n for n in np.flatnonzero(bondmatrix[center[0], :]) if n != center[1]]
-    neigh_r = [n for n in np.flatnonzero(bondmatrix[center[-1], :]) if n != center[-2]]
+    neigh_l = [n for n in np.flatnonzero(bondmatrix[center[0], :]) if n not in center]
+    neigh_r = [n for n in np.flatnonzero(bondmatrix[center[-1], :]) if n not in center]
     angles_l = [Angle(i, center[0], center[1]).eval(coords) for i in neigh_l]
     angles_r = [Angle(center[-2], center[-1], j).eval(coords) for j in neigh_r]
-    nonlinear_l = [n for n, ang in zip(neigh_l, angles_l) if ang < pi-1e-3]
-    nonlinear_r = [n for n, ang in zip(neigh_r, angles_r) if ang < pi-1e-3]
-    linear_l = [n for n, ang in zip(neigh_l, angles_l) if ang > pi-1e-3]
-    linear_r = [n for n, ang in zip(neigh_r, angles_r) if ang > pi-1e-3]
+    nonlinear_l = [n for n, ang in zip(neigh_l, angles_l) if ang < pi-1e-3 and ang >= 1e-3]
+    nonlinear_r = [n for n, ang in zip(neigh_r, angles_r) if ang < pi-1e-3 and ang >= 1e-3]
+    linear_l = [n for n, ang in zip(neigh_l, angles_l) if ang >= pi-1e-3 or ang < 1e-3]
+    linear_r = [n for n, ang in zip(neigh_r, angles_r) if ang >= pi-1e-3 or ang < 1e-3]
     assert len(linear_l) <= 1
     assert len(linear_r) <= 1
     if center[0] < center[-1]:


### PR DESCRIPTION
Hi,

In the previous one, it is possible to find dihedrals with repeating atoms, leading to DivisionByZero error (i.e. generating nan). The fixed code resolved this issue.

I do not know if we need to modify ```angles_r = [Angle(center[-2], center[-1], j).eval(coords) for j in neigh_r]``` to ... ```center[0], center[-1]``` ... Please modify it accordingly if necessary.

